### PR TITLE
EmuHawk: Implement OpenTK controllers on unix - also tested and working on Windows (but disabled for now)

### DIFF
--- a/BizHawk.Client.EmuHawk/BizHawk.Client.EmuHawk.csproj
+++ b/BizHawk.Client.EmuHawk/BizHawk.Client.EmuHawk.csproj
@@ -84,7 +84,7 @@
       <HintPath>..\output\dll\nlua\NLua.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="OpenTK, Version=1.1.0.0, Culture=neutral, PublicKeyToken=bad199fe84eb3df4, processorArchitecture=MSIL">
+    <Reference Include="OpenTK, Version=3.0.1.0, Culture=neutral, PublicKeyToken=bad199fe84eb3df4, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\References\OpenTK.dll</HintPath>
     </Reference>

--- a/BizHawk.Client.EmuHawk/Input/Input.cs
+++ b/BizHawk.Client.EmuHawk/Input/Input.cs
@@ -132,9 +132,9 @@ namespace BizHawk.Client.EmuHawk
 			{
 				KeyInput.Initialize();
 				IPCKeyInput.Initialize();
-				//GamePad.Initialize();
-				//GamePad360.Initialize();
-				OTK_GamePad.Initialize();
+				GamePad.Initialize();
+				GamePad360.Initialize();
+				//OTK_GamePad.Initialize();
 			}
 			Instance = new Input();
 		}
@@ -341,9 +341,9 @@ namespace BizHawk.Client.EmuHawk
 				}
 				else
 				{
-					//GamePad.UpdateAll();
-					//GamePad360.UpdateAll();
-					OTK_GamePad.UpdateAll();
+					GamePad.UpdateAll();
+					GamePad360.UpdateAll();
+					//OTK_GamePad.UpdateAll();
 				}
 
 				//this block is going to massively modify data structures that the binding method uses, so we have to lock it all

--- a/BizHawk.Client.EmuHawk/Input/Input.cs
+++ b/BizHawk.Client.EmuHawk/Input/Input.cs
@@ -132,9 +132,9 @@ namespace BizHawk.Client.EmuHawk
 			{
 				KeyInput.Initialize();
 				IPCKeyInput.Initialize();
-				GamePad.Initialize();
-				GamePad360.Initialize();
-				//OTK_GamePad.Initialize();
+				//GamePad.Initialize();
+				//GamePad360.Initialize();
+				OTK_GamePad.Initialize();
 			}
 			Instance = new Input();
 		}
@@ -341,9 +341,9 @@ namespace BizHawk.Client.EmuHawk
 				}
 				else
 				{
-					GamePad.UpdateAll();
-					GamePad360.UpdateAll();
-					//OTK_GamePad.UpdateAll();
+					//GamePad.UpdateAll();
+					//GamePad360.UpdateAll();
+					OTK_GamePad.UpdateAll();
 				}
 
 				//this block is going to massively modify data structures that the binding method uses, so we have to lock it all

--- a/BizHawk.Client.EmuHawk/Input/Input.cs
+++ b/BizHawk.Client.EmuHawk/Input/Input.cs
@@ -132,8 +132,9 @@ namespace BizHawk.Client.EmuHawk
 			{
 				KeyInput.Initialize();
 				IPCKeyInput.Initialize();
-				GamePad.Initialize();
-				GamePad360.Initialize();
+				//GamePad.Initialize();
+				//GamePad360.Initialize();
+				OTK_GamePad.Initialize();
 			}
 			Instance = new Input();
 		}
@@ -340,8 +341,9 @@ namespace BizHawk.Client.EmuHawk
 				}
 				else
 				{
-					GamePad.UpdateAll();
-					GamePad360.UpdateAll();
+					//GamePad.UpdateAll();
+					//GamePad360.UpdateAll();
+					OTK_GamePad.UpdateAll();
 				}
 
 				//this block is going to massively modify data structures that the binding method uses, so we have to lock it all
@@ -360,9 +362,13 @@ namespace BizHawk.Client.EmuHawk
 						//analyze OTK xinput (libinput?)
 						foreach (var pad in OTK_GamePad.EnumerateDevices())
 						{
-							string xname = pad.ID + " ";
-							for (int b = 0; b < pad.NumButtons; b++)
-								HandleButton(xname + pad.ButtonName(b), pad.Pressed(b));
+							string xname = "X" + pad.ID + " ";
+
+							foreach (var but in pad.buttonObjects)
+							{
+								HandleButton(xname + but.ButtonName, but.ButtonAction());
+							}
+
 							foreach (var sv in pad.GetFloats())
 							{
 								string n = xname + sv.Item1;

--- a/BizHawk.Client.EmuHawk/Input/Input.cs
+++ b/BizHawk.Client.EmuHawk/Input/Input.cs
@@ -362,7 +362,8 @@ namespace BizHawk.Client.EmuHawk
 						//analyze OTK
 						foreach (var pad in OTK_GamePad.EnumerateDevices())
 						{
-							string xname = "T" + pad.ID + " ";
+							string cType = pad.MappedGamePad ? "X" : "J";
+							string xname = cType + pad.ID + " ";
 
 							foreach (var but in pad.buttonObjects)
 							{								

--- a/BizHawk.Client.EmuHawk/Input/Input.cs
+++ b/BizHawk.Client.EmuHawk/Input/Input.cs
@@ -132,9 +132,9 @@ namespace BizHawk.Client.EmuHawk
 			{
 				KeyInput.Initialize();
 				IPCKeyInput.Initialize();
-				//GamePad.Initialize();
-				//GamePad360.Initialize();
-				OTK_GamePad.Initialize();
+				GamePad.Initialize();
+				GamePad360.Initialize();
+				//OTK_GamePad.Initialize();
 			}
 			Instance = new Input();
 		}
@@ -341,9 +341,9 @@ namespace BizHawk.Client.EmuHawk
 				}
 				else
 				{
-					//GamePad.UpdateAll();
-					//GamePad360.UpdateAll();
-					OTK_GamePad.UpdateAll();
+					GamePad.UpdateAll();
+					GamePad360.UpdateAll();
+					//OTK_GamePad.UpdateAll();
 				}
 
 				//this block is going to massively modify data structures that the binding method uses, so we have to lock it all
@@ -359,19 +359,19 @@ namespace BizHawk.Client.EmuHawk
 					{
 						//FloatValues.Clear();
 
-						//analyze OTK xinput (libinput?)
+						//analyze OTK
 						foreach (var pad in OTK_GamePad.EnumerateDevices())
 						{
-							string xname = "X" + pad.ID + " ";
+							string xname = "T" + pad.ID + " ";
 
 							foreach (var but in pad.buttonObjects)
-							{
+							{								
 								HandleButton(xname + but.ButtonName, but.ButtonAction());
 							}
-
+							
 							foreach (var sv in pad.GetFloats())
 							{
-								string n = xname + sv.Item1;
+								string n = xname + sv.Item1 + " Axis";
 								float f = sv.Item2;
 								if (trackdeltas)
 									FloatDeltas[n] += Math.Abs(f - FloatValues[n]);

--- a/BizHawk.Client.EmuHawk/Input/OTK_Gamepad.cs
+++ b/BizHawk.Client.EmuHawk/Input/OTK_Gamepad.cs
@@ -176,13 +176,31 @@ namespace BizHawk.Client.EmuHawk
 
 		public IEnumerable<Tuple<string, float>> GetFloats()
 		{
-			yield return new Tuple<string, float>("LeftThumbX", state.ThumbSticks.Left.X);
-			yield return new Tuple<string, float>("LeftThumbY", state.ThumbSticks.Left.Y);
-			yield return new Tuple<string, float>("RightThumbX", state.ThumbSticks.Right.X);
-			yield return new Tuple<string, float>("RightThumbY", state.ThumbSticks.Right.Y);
-			yield return new Tuple<string, float>("LeftTrigger", state.Triggers.Left);
-			yield return new Tuple<string, float>("RightTrigger", state.Triggers.Right);
-			yield break;
+			if (!_gamePadCapabilities.HasValue || !_gamePadCapabilities.Value.IsMapped)
+			{
+				yield return new Tuple<string, float>("LeftThumbX", state.ThumbSticks.Left.X);
+				yield return new Tuple<string, float>("LeftThumbY", state.ThumbSticks.Left.Y);
+				yield return new Tuple<string, float>("RightThumbX", state.ThumbSticks.Right.X);
+				yield return new Tuple<string, float>("RightThumbY", state.ThumbSticks.Right.Y);
+				yield return new Tuple<string, float>("LeftTrigger", state.Triggers.Left);
+				yield return new Tuple<string, float>("RightTrigger", state.Triggers.Right);
+				yield break;
+			}
+			else
+			{
+				for (int i = 0; i < _joystickCapabilities.Value.AxisCount; i++)
+				{
+					if (i <= 2)
+					{
+						yield return new Tuple<string, float>("AXIS " + aNames[i], jState.GetAxis(i));
+					}
+					else
+					{
+						yield return new Tuple<string, float>("AXIS " + i, jState.GetAxis(i));
+					}
+					yield break;
+				}
+			}
 		}
 
 		public string Name { get { return "Joystick " + _playerIndex + string.Format(" ({0})", _name); } }
@@ -232,6 +250,8 @@ namespace BizHawk.Client.EmuHawk
 			}
 		}
 
+		string[] aNames = new string[] { "X", "Y", "Z", "AXIS" };
+
 		void InitializeJoystickControls()
 		{
 			const float ConversionFactor = 1.0f / short.MaxValue;
@@ -256,8 +276,7 @@ namespace BizHawk.Client.EmuHawk
 				AddItem(string.Format("POV{0}R", i + 1), () => hat.IsRight);
 			}
 
-			// axis
-			string[] aNames = new string[] { "X", "Y", "Z", "AXIS" };
+			// axis			
 			for (int i = 0; i < _joystickCapabilities.Value.AxisCount; i++)
 			{
 				switch (i)

--- a/BizHawk.Client.EmuHawk/Input/OTK_Gamepad.cs
+++ b/BizHawk.Client.EmuHawk/Input/OTK_Gamepad.cs
@@ -26,19 +26,15 @@ namespace BizHawk.Client.EmuHawk
 			Devices.Clear();
 
 			int playerCount = 0;
-
-			//lock (_syncObj)
-			//{
-				for (int i = 0; i < MAX_GAMEPADS; i++)
+			for (int i = 0; i < MAX_GAMEPADS; i++)
+			{
+				if (OpenTK.Input.GamePad.GetState(i).IsConnected || Joystick.GetState(i).IsConnected)
 				{
-					if (/*OpenTK.Input.GamePad.GetState(i).IsConnected || */Joystick.GetState(i).IsConnected)
-					{
-						Console.WriteLine(string.Format("OTK GamePad/Joystick index: {0}", i));
-						OTK_GamePad ogp = new OTK_GamePad(i, ++playerCount);
-						Devices.Add(ogp);
-					}
+					Console.WriteLine(string.Format("OTK GamePad/Joystick index: {0}", i));
+					OTK_GamePad ogp = new OTK_GamePad(i, ++playerCount);
+					Devices.Add(ogp);
 				}
-			//}
+			}
 		}
 
 		public static IEnumerable<OTK_GamePad> EnumerateDevices()

--- a/BizHawk.Client.EmuHawk/Input/OTK_Gamepad.cs
+++ b/BizHawk.Client.EmuHawk/Input/OTK_Gamepad.cs
@@ -122,6 +122,20 @@ namespace BizHawk.Client.EmuHawk
 		readonly bool _hasJoystick;
 
 		/// <summary>
+		/// Public check on whether mapped gamepad config is being used
+		/// </summary>
+		public bool MappedGamePad
+		{
+			get
+			{
+				if (_gamePadCapabilities.HasValue && _gamePadCapabilities.Value.IsMapped)
+					return true;
+
+				return false;
+			}
+		}
+
+		/// <summary>
 		/// Gamepad Device state information - updated constantly
 		/// </summary>
 		GamePadState state = new GamePadState();

--- a/BizHawk.Client.EmuHawk/Input/OTK_Gamepad.cs
+++ b/BizHawk.Client.EmuHawk/Input/OTK_Gamepad.cs
@@ -107,19 +107,9 @@ namespace BizHawk.Client.EmuHawk
 		readonly GamePadCapabilities? _gamePadCapabilities;
 
 		/// <summary>
-		/// Has OpenTK detected the device using the GamePad class?
-		/// </summary>
-		readonly bool _hasGamepad;
-
-		/// <summary>
 		/// The object as returned by OpenTK.Input.Joystick.GetCapabilities();
 		/// </summary>
 		readonly JoystickCapabilities? _joystickCapabilities;
-
-		/// <summary>
-		/// Has OpenTK detected the device using the Joystick class?
-		/// </summary>
-		readonly bool _hasJoystick;
 
 		/// <summary>
 		/// Public check on whether mapped gamepad config is being used
@@ -139,13 +129,11 @@ namespace BizHawk.Client.EmuHawk
 		/// Gamepad Device state information - updated constantly
 		/// </summary>
 		GamePadState state = new GamePadState();
-		GamePadState oldState = new GamePadState();
 
 		/// <summary>
 		/// Joystick Device state information - updated constantly
 		/// </summary>
 		JoystickState jState = new JoystickState();
-		JoystickState oldJstate = new JoystickState();
 
 		OTK_GamePad(int index, int playerIndex)
 		{
@@ -291,6 +279,11 @@ namespace BizHawk.Client.EmuHawk
 		/// </summary>
 		void InitializeMappings()
 		{
+			if (_guidObtained)
+			{
+				// placeholder for if/when we figure out how to supply OpenTK with custom GamePadConfigurationDatabase entries
+			}
+
 			// currently OpenTK has an internal database of mappings for the GamePad class: https://github.com/opentk/opentk/blob/master/src/OpenTK/Input/GamePadConfigurationDatabase.cs
 			// if an internal mapping is detected, use that. otherwise, use the joystick class to instantiate the controller
 			if (!_gamePadCapabilities.HasValue || !_gamePadCapabilities.Value.IsMapped)

--- a/BizHawk.Client.EmuHawk/Input/OTK_Gamepad.cs
+++ b/BizHawk.Client.EmuHawk/Input/OTK_Gamepad.cs
@@ -27,8 +27,8 @@ namespace BizHawk.Client.EmuHawk
 
 			int playerCount = 0;
 
-			lock (_syncObj)
-			{
+			//lock (_syncObj)
+			//{
 				for (int i = 0; i < MAX_GAMEPADS; i++)
 				{
 					if (/*OpenTK.Input.GamePad.GetState(i).IsConnected || */Joystick.GetState(i).IsConnected)
@@ -38,7 +38,7 @@ namespace BizHawk.Client.EmuHawk
 						Devices.Add(ogp);
 					}
 				}
-			}
+			//}
 		}
 
 		public static IEnumerable<OTK_GamePad> EnumerateDevices()

--- a/BizHawk.Client.EmuHawk/Input/OTK_Gamepad.cs
+++ b/BizHawk.Client.EmuHawk/Input/OTK_Gamepad.cs
@@ -313,7 +313,7 @@ namespace BizHawk.Client.EmuHawk
 			const float ConversionFactor = 1.0f / short.MaxValue;
 			const float dzp = (short)400 * ConversionFactor;
 			const float dzn = (short)-400 * ConversionFactor;
-			const float dzt = 0.6f;
+			//const float dzt = 0.6f;
 
 			// axis		
 			AddItem("X+", () => jState.GetAxis(0) >= dzp);
@@ -343,14 +343,22 @@ namespace BizHawk.Client.EmuHawk
 			}
 
 			// hats
-			for (int i = 0; i < _joystickCapabilities.Value.HatCount; i++)
-			{
-				JoystickHatState hat = jState.GetHat((JoystickHat)i);
-				AddItem(string.Format("POV{0}U", i + 1), () => hat.IsUp);
-				AddItem(string.Format("POV{0}D", i + 1), () => hat.IsDown);
-				AddItem(string.Format("POV{0}L", i + 1), () => hat.IsLeft);
-				AddItem(string.Format("POV{0}R", i + 1), () => hat.IsRight);
-			}
+			AddItem("POV1U", () => jState.GetHat(JoystickHat.Hat0).IsUp);
+			AddItem("POV1D", () => jState.GetHat(JoystickHat.Hat0).IsDown);
+			AddItem("POV1L", () => jState.GetHat(JoystickHat.Hat0).IsLeft);
+			AddItem("POV1R", () => jState.GetHat(JoystickHat.Hat0).IsRight);
+			AddItem("POV2U", () => jState.GetHat(JoystickHat.Hat1).IsUp);
+			AddItem("POV2D", () => jState.GetHat(JoystickHat.Hat1).IsDown);
+			AddItem("POV2L", () => jState.GetHat(JoystickHat.Hat1).IsLeft);
+			AddItem("POV2R", () => jState.GetHat(JoystickHat.Hat1).IsRight);
+			AddItem("POV3U", () => jState.GetHat(JoystickHat.Hat2).IsUp);
+			AddItem("POV3D", () => jState.GetHat(JoystickHat.Hat2).IsDown);
+			AddItem("POV3L", () => jState.GetHat(JoystickHat.Hat2).IsLeft);
+			AddItem("POV3R", () => jState.GetHat(JoystickHat.Hat2).IsRight);
+			AddItem("POV4U", () => jState.GetHat(JoystickHat.Hat3).IsUp);
+			AddItem("POV4D", () => jState.GetHat(JoystickHat.Hat3).IsDown);
+			AddItem("POV4L", () => jState.GetHat(JoystickHat.Hat3).IsLeft);
+			AddItem("POV4R", () => jState.GetHat(JoystickHat.Hat3).IsRight);			
 		}
 
 		void InitializeGamePadControls()

--- a/BizHawk.Client.EmuHawk/Input/OTK_Gamepad.cs
+++ b/BizHawk.Client.EmuHawk/Input/OTK_Gamepad.cs
@@ -31,7 +31,7 @@ namespace BizHawk.Client.EmuHawk
 			{
 				for (int i = 0; i < MAX_GAMEPADS; i++)
 				{
-					if (OpenTK.Input.GamePad.GetState(i).IsConnected || Joystick.GetState(i).IsConnected)
+					if (/*OpenTK.Input.GamePad.GetState(i).IsConnected || */Joystick.GetState(i).IsConnected)
 					{
 						Console.WriteLine(string.Format("OTK GamePad/Joystick index: {0}", i));
 						OTK_GamePad ogp = new OTK_GamePad(i, ++playerCount);

--- a/BizHawk.Client.EmuHawk/Input/OTK_Gamepad.cs
+++ b/BizHawk.Client.EmuHawk/Input/OTK_Gamepad.cs
@@ -12,7 +12,7 @@ namespace BizHawk.Client.EmuHawk
 		//And it looks like GamePad itself isn't supported on OpenTK OS X.
 
 		private static readonly object _syncObj = new object();
-		public static List<OTK_GamePad> Devices;
+		public static List<OTK_GamePad> Devices = new List<OTK_GamePad>();
 		private const int MAX_JOYSTICKS = 4; //They don't have a way to query this for some reason. 4 is the minimum promised.
 
 		public static void Initialize()

--- a/BizHawk.Client.EmuHawk/Input/OTK_Gamepad.cs
+++ b/BizHawk.Client.EmuHawk/Input/OTK_Gamepad.cs
@@ -8,32 +8,36 @@ namespace BizHawk.Client.EmuHawk
 	{
 		// Modified OpenTK Gamepad Handler
 		// OpenTK v3.x.x.x breaks the original OpenTK.Input.Joystick implementation, but enables OpenTK.Input.Gamepad 
-		// compatibility with OSX / linux
-		// This should also give us vibration support (if we implement it)
+		// compatibility with OSX / linux. However, the gamepad auto-mapping is a little suspect, so we will have to use both methods
+		// This should also give us vibration support (if we ever implement it)
+
+		#region Static Members
 
 		private static readonly object _syncObj = new object();
-		public static List<OTK_GamePad> Devices = new List<OTK_GamePad>();
 		private const int MAX_GAMEPADS = 4; //They don't have a way to query this for some reason. 4 is the minimum promised.
+		public static List<OTK_GamePad> Devices = new List<OTK_GamePad>();		
 
+		/// <summary>
+		/// Initialization is only called once when MainForm loads
+		/// </summary>
 		public static void Initialize()
 		{
 			Devices.Clear();
+
+			int playerCount = 0;
 
 			lock (_syncObj)
 			{
 				for (int i = 0; i < MAX_GAMEPADS; i++)
 				{
-					GamePadState gps = OpenTK.Input.GamePad.GetState(i);
-					if (gps.IsConnected)
+					if (OpenTK.Input.GamePad.GetState(i).IsConnected || Joystick.GetState(i).IsConnected)
 					{
-						Console.WriteLine(string.Format("joydevice index: {0}", i)); //OpenTK doesn't expose the GUID, even though it stores it internally...
-						string gpn = OpenTK.Input.GamePad.GetName(i);
-						GamePadCapabilities gpc = OpenTK.Input.GamePad.GetCapabilities(i);
-						OTK_GamePad ogp = new OTK_GamePad(i, gpn, gpc);
+						Console.WriteLine(string.Format("OTK GamePad/Joystick index: {0}", i));
+						OTK_GamePad ogp = new OTK_GamePad(i, ++playerCount);
 						Devices.Add(ogp);
 					}
 				}
-			}			
+			}
 		}
 
 		public static IEnumerable<OTK_GamePad> EnumerateDevices()
@@ -66,33 +70,112 @@ namespace BizHawk.Client.EmuHawk
 			}
 		}
 
-		// ********************************** Instance Members **********************************
+		#endregion
 
-		readonly Guid _guid;
-		readonly int _stickIdx;
+		#region Instance Members
+
+		/// <summary>
+		/// The GUID as detected by OpenTK.Input.Joystick
+		/// (or auto generated if this failed)
+		/// </summary>
+		readonly Guid _guid = Guid.NewGuid();
+
+		/// <summary>
+		/// Signs whether OpenTK returned a GUID for this device
+		/// </summary>
+		readonly bool _guidObtained;
+
+		/// <summary>
+		/// The OpenTK device index
+		/// </summary>
+		readonly int _deviceIndex;
+
+		/// <summary>
+		/// The index to lookup into Devices
+		/// </summary>
+		readonly int _playerIndex;
+
+		/// <summary>
+		/// The name (if any) that OpenTK GamePad has resolved via its internal mapping database
+		/// </summary>
 		readonly string _name;
-		readonly GamePadCapabilities _capabilities;
+
+		/// <summary>
+		/// The object as returned by OpenTK.Input.Gamepad.GetCapabilities();
+		/// </summary>
+		readonly GamePadCapabilities? _gamePadCapabilities;
+
+		/// <summary>
+		/// Has OpenTK detected the device using the GamePad class?
+		/// </summary>
+		readonly bool _hasGamepad;
+
+		/// <summary>
+		/// The object as returned by OpenTK.Input.Joystick.GetCapabilities();
+		/// </summary>
+		readonly JoystickCapabilities? _joystickCapabilities;
+
+		/// <summary>
+		/// Has OpenTK detected the device using the Joystick class?
+		/// </summary>
+		readonly bool _hasJoystick;
+
+		/// <summary>
+		/// Gamepad Device state information - updated constantly
+		/// </summary>
 		GamePadState state = new GamePadState();
 
-		OTK_GamePad(int index, string name, GamePadCapabilities capabilities)
+		/// <summary>
+		/// Joystick Device state information - updated constantly
+		/// </summary>
+		JoystickState jState = new JoystickState();
+
+		OTK_GamePad(int index, int playerIndex)
 		{
-			_guid = Guid.NewGuid();
-			_stickIdx = index;
-			_name = name;
-			_capabilities = capabilities;
+			_deviceIndex = index;
+			_playerIndex = playerIndex;
+
+			var gameState = OpenTK.Input.GamePad.GetState(_deviceIndex);
+			var joyState = Joystick.GetState(_deviceIndex);
+
+			if (joyState.IsConnected)
+			{
+				_guid = Joystick.GetGuid(_deviceIndex);
+				_guidObtained = true;
+				_joystickCapabilities = Joystick.GetCapabilities(_deviceIndex);
+			}
+			else
+			{
+				_guid = Guid.NewGuid();
+			}
+
+			if (gameState.IsConnected)
+			{
+				_name = OpenTK.Input.GamePad.GetName(_deviceIndex);
+				_gamePadCapabilities = OpenTK.Input.GamePad.GetCapabilities(_deviceIndex);
+			}
+			else
+			{
+				_name = "OTK GamePad Undetermined Name";
+			}
+			
 			Update();
-			InitializeButtons();
-			Console.WriteLine("Initialised OpenTK GamePad: " + Name);
+
+			Console.WriteLine("Initialising OpenTK GamePad: " + _guid);
 			Console.WriteLine("OpenTK Mapping: " + _name);
+
+			InitializeMappings();			
 		}
 
 		public void Update()
 		{
-			state = OpenTK.Input.GamePad.GetState(_stickIdx);
+			// update both here just in case
+			state = OpenTK.Input.GamePad.GetState(_deviceIndex);
+			jState = Joystick.GetState(_deviceIndex);
 		}
 
 		public IEnumerable<Tuple<string, float>> GetFloats()
-		{			
+		{
 			yield return new Tuple<string, float>("LeftThumbX", state.ThumbSticks.Left.X);
 			yield return new Tuple<string, float>("LeftThumbY", state.ThumbSticks.Left.Y);
 			yield return new Tuple<string, float>("RightThumbX", state.ThumbSticks.Right.X);
@@ -102,40 +185,17 @@ namespace BizHawk.Client.EmuHawk
 			yield break;
 		}
 
-		/// <summary>FOR DEBUGGING ONLY</summary>
-		public GamePadState GetInternalState()
-		{
-			return state;
-		}
-
-		public string Name { get { return "Joystick " + _stickIdx + string.Format(" ({0})", _name); } }
-		public string ID { get { return (_stickIdx + 1).ToString(); } }
+		public string Name { get { return "Joystick " + _playerIndex + string.Format(" ({0})", _name); } }
+		public string ID { get { return (_playerIndex).ToString(); } }
 		public Guid Guid { get { return _guid; } }
 
-		/*
-		public string ButtonName(int index)
-		{
-			return names[index];
-		}
-		public bool Pressed(int index)
-		{
-			return actions[index]();
-		}
-		
-		public int NumButtons { get; private set; }
-		
-
-		private readonly List<string> names = new List<string>();
-		private readonly List<Func<bool>> actions = new List<Func<bool>>();
-		*/
-		public readonly List<ButtonObject> buttonObjects = new List<ButtonObject>();
+		/// <summary>
+		/// Contains name and delegate function for all buttons, hats and axis
+		/// </summary>
+		public List<ButtonObject> buttonObjects = new List<ButtonObject>();
 
 		void AddItem(string _name, Func<bool> pressed)
 		{
-			//names.Add(_name);
-			//actions.Add(pressed);
-			//NumButtons++;
-
 			ButtonObject b = new ButtonObject
 			{
 				ButtonName = _name,
@@ -145,60 +205,139 @@ namespace BizHawk.Client.EmuHawk
 			buttonObjects.Add(b);
 		}
 
-		void InitializeButtons()
+		public struct ButtonObject
 		{
-			// OpenTK GamePad axis return float values
+			public string ButtonName;
+			public Func<bool> ButtonAction;
+		}
+
+		/// <summary>
+		/// Setup mappings prior to button initialization
+		/// This is also here in case in the future we want users to be able to supply their own mappings for a device,
+		/// perhaps via an input form. Possibly wishful thinking/overly complex.
+		/// </summary>
+		void InitializeMappings()
+		{
+			// currently OpenTK has an internal database of mappings for the GamePad class: https://github.com/opentk/opentk/blob/master/src/OpenTK/Input/GamePadConfigurationDatabase.cs
+			// if an internal mapping is detected, use that. otherwise, use the joystick class to instantiate the controller
+			if (!_gamePadCapabilities.HasValue || !_gamePadCapabilities.Value.IsMapped)
+			{
+				// no internal map detected - use the joystick class
+				InitializeJoystickControls();
+			}
+			else
+			{
+				// internal map detected - use the GamePad class
+				InitializeGamePadControls();
+			}
+		}
+
+		void InitializeJoystickControls()
+		{
 			const float ConversionFactor = 1.0f / short.MaxValue;
 			const float dzp = (short)400 * ConversionFactor;
 			const float dzn = (short)-400 * ConversionFactor;
-			const float dzt = 0.6f; // (short)10 * ConversionFactor;
+			const float dzt = 0.6f;
 
 			// buttons
-			if (_capabilities.HasAButton) AddItem("A", () => state.Buttons.A == ButtonState.Pressed);
-			if (_capabilities.HasBButton) AddItem("B", () => state.Buttons.B == ButtonState.Pressed);
-			if (_capabilities.HasXButton) AddItem("X", () => state.Buttons.X == ButtonState.Pressed);
-			if (_capabilities.HasYButton) AddItem("Y", () => state.Buttons.Y == ButtonState.Pressed);
-			if (_capabilities.HasBigButton) AddItem("Guide", () => state.Buttons.BigButton == ButtonState.Pressed);
-			if (_capabilities.HasStartButton) AddItem("Start", () => state.Buttons.Start == ButtonState.Pressed);
-			if (_capabilities.HasBackButton) AddItem("Back", () => state.Buttons.Back == ButtonState.Pressed);
-			if (_capabilities.HasLeftStickButton) AddItem("LeftThumb", () => state.Buttons.LeftStick == ButtonState.Pressed);
-			if (_capabilities.HasRightStickButton) AddItem("RightThumb", () => state.Buttons.RightStick == ButtonState.Pressed);
-			if (_capabilities.HasLeftShoulderButton) AddItem("LeftShoulder", () => state.Buttons.LeftShoulder == ButtonState.Pressed);
-			if (_capabilities.HasRightShoulderButton) AddItem("RightShoulder", () => state.Buttons.RightShoulder == ButtonState.Pressed);
+			for (int i = 0; i < _joystickCapabilities.Value.ButtonCount; i++)
+			{
+				int j = i;
+				AddItem(string.Format("B{0}", i + 1), () => jState.GetButton(j) == ButtonState.Pressed);
+			}
+
+			// hats
+			for (int i = 0; i < _joystickCapabilities.Value.HatCount; i++)
+			{
+				JoystickHatState hat = jState.GetHat((JoystickHat)i);
+				AddItem(string.Format("POV{0}U", i + 1), () => hat.IsUp);
+				AddItem(string.Format("POV{0}D", i + 1), () => hat.IsDown);
+				AddItem(string.Format("POV{0}L", i + 1), () => hat.IsLeft);
+				AddItem(string.Format("POV{0}R", i + 1), () => hat.IsRight);
+			}
+
+			// axis
+			string[] aNames = new string[] { "X", "Y", "Z", "AXIS" };
+			for (int i = 0; i < _joystickCapabilities.Value.AxisCount; i++)
+			{
+				switch (i)
+				{
+					// X
+					case 0:
+						AddItem("X+", () => jState.GetAxis(i) >= dzp);
+						AddItem("X-", () => jState.GetAxis(i) <= dzn);
+						break;
+					// Y
+					case 1:
+						AddItem("Y+", () => jState.GetAxis(i) >= dzp);
+						AddItem("Y-", () => jState.GetAxis(i) <= dzn);
+						break;
+					// Z
+					case 2:
+						AddItem("Z+", () => jState.GetAxis(i) >= dzp);
+						AddItem("Z-", () => jState.GetAxis(i) <= dzn);
+						break;
+					default:
+						AddItem(string.Format("AXIS{0}+", i), () => jState.GetAxis(i) >= dzp);
+						AddItem(string.Format("AXIS{0}-", i), () => jState.GetAxis(i) <= dzn);
+						break;
+				}
+			}	
+		}
+
+		void InitializeGamePadControls()
+		{
+			// OpenTK GamePad axis return float values (as opposed to the shorts of SlimDX)
+			const float ConversionFactor = 1.0f / short.MaxValue;
+			const float dzp = (short)400 * ConversionFactor;
+			const float dzn = (short)-400 * ConversionFactor;
+			const float dzt = 0.6f;
+
+			// buttons
+			if (_gamePadCapabilities.Value.HasAButton) AddItem("A", () => state.Buttons.A == ButtonState.Pressed);
+			if (_gamePadCapabilities.Value.HasBButton) AddItem("B", () => state.Buttons.B == ButtonState.Pressed);
+			if (_gamePadCapabilities.Value.HasXButton) AddItem("X", () => state.Buttons.X == ButtonState.Pressed);
+			if (_gamePadCapabilities.Value.HasYButton) AddItem("Y", () => state.Buttons.Y == ButtonState.Pressed);
+			if (_gamePadCapabilities.Value.HasBigButton) AddItem("Guide", () => state.Buttons.BigButton == ButtonState.Pressed);
+			if (_gamePadCapabilities.Value.HasStartButton) AddItem("Start", () => state.Buttons.Start == ButtonState.Pressed);
+			if (_gamePadCapabilities.Value.HasBackButton) AddItem("Back", () => state.Buttons.Back == ButtonState.Pressed);
+			if (_gamePadCapabilities.Value.HasLeftStickButton) AddItem("LeftThumb", () => state.Buttons.LeftStick == ButtonState.Pressed);
+			if (_gamePadCapabilities.Value.HasRightStickButton) AddItem("RightThumb", () => state.Buttons.RightStick == ButtonState.Pressed);
+			if (_gamePadCapabilities.Value.HasLeftShoulderButton) AddItem("LeftShoulder", () => state.Buttons.LeftShoulder == ButtonState.Pressed);
+			if (_gamePadCapabilities.Value.HasRightShoulderButton) AddItem("RightShoulder", () => state.Buttons.RightShoulder == ButtonState.Pressed);
 
 			// dpad
-			if (_capabilities.HasDPadUpButton) AddItem("DpadUp", () => state.DPad.Up == ButtonState.Pressed);
-			if (_capabilities.HasDPadDownButton) AddItem("DpadDown", () => state.DPad.Down == ButtonState.Pressed);
-			if (_capabilities.HasDPadLeftButton) AddItem("DpadLeft", () => state.DPad.Left == ButtonState.Pressed);
-			if (_capabilities.HasDPadRightButton) AddItem("DpadRight", () => state.DPad.Right == ButtonState.Pressed);
+			if (_gamePadCapabilities.Value.HasDPadUpButton) AddItem("DpadUp", () => state.DPad.Up == ButtonState.Pressed);
+			if (_gamePadCapabilities.Value.HasDPadDownButton) AddItem("DpadDown", () => state.DPad.Down == ButtonState.Pressed);
+			if (_gamePadCapabilities.Value.HasDPadLeftButton) AddItem("DpadLeft", () => state.DPad.Left == ButtonState.Pressed);
+			if (_gamePadCapabilities.Value.HasDPadRightButton) AddItem("DpadRight", () => state.DPad.Right == ButtonState.Pressed);
 
 			// sticks
-			if (_capabilities.HasLeftYThumbStick)
+			if (_gamePadCapabilities.Value.HasLeftYThumbStick)
 			{
 				AddItem("LStickUp", () => state.ThumbSticks.Left.Y >= dzp);
 				AddItem("LStickDown", () => state.ThumbSticks.Left.Y <= dzn);
 			}
-			if (_capabilities.HasLeftXThumbStick)
+			if (_gamePadCapabilities.Value.HasLeftXThumbStick)
 			{
 				AddItem("LStickLeft", () => state.ThumbSticks.Left.X <= dzn);
 				AddItem("LStickRight", () => state.ThumbSticks.Left.X >= dzp);
 			}
-			if (_capabilities.HasRightYThumbStick)
+			if (_gamePadCapabilities.Value.HasRightYThumbStick)
 			{
 				AddItem("RStickUp", () => state.ThumbSticks.Right.Y >= dzp);
 				AddItem("RStickDown", () => state.ThumbSticks.Right.Y <= dzn);
 			}
-			if (_capabilities.HasRightXThumbStick)
+			if (_gamePadCapabilities.Value.HasRightXThumbStick)
 			{
 				AddItem("RStickLeft", () => state.ThumbSticks.Right.X <= dzn);
 				AddItem("RStickRight", () => state.ThumbSticks.Right.X >= dzp);
 			}
 
 			// triggers
-			if (_capabilities.HasLeftTrigger) AddItem("LeftTrigger", () => state.Triggers.Left > dzt);
-			if (_capabilities.HasRightTrigger) AddItem("RightTrigger", () => state.Triggers.Right > dzt);
-
-		}		
+			if (_gamePadCapabilities.Value.HasLeftTrigger) AddItem("LeftTrigger", () => state.Triggers.Left > dzt);
+			if (_gamePadCapabilities.Value.HasRightTrigger) AddItem("RightTrigger", () => state.Triggers.Right > dzt);
+		}
 
 		/// <summary>
 		/// Sets the gamepad's left and right vibration
@@ -211,19 +350,15 @@ namespace BizHawk.Client.EmuHawk
 			float _l = 0;
 			float _r = 0;
 
-			if (_capabilities.HasLeftVibrationMotor)
+			if (_gamePadCapabilities.Value.HasLeftVibrationMotor)
 				_l = left;
-			if (_capabilities.HasRightVibrationMotor)
+			if (_gamePadCapabilities.Value.HasRightVibrationMotor)
 				_r = right;
 
-			OpenTK.Input.GamePad.SetVibration(_stickIdx, left, right);
-		}
+			OpenTK.Input.GamePad.SetVibration(_deviceIndex, left, right);
+		}		
 
-		public class ButtonObject
-		{
-			public string ButtonName;
-			public Func<bool> ButtonAction;
-		}
+		#endregion
 	}
 }
 

--- a/Bizware/BizHawk.Bizware.BizwareGL.GdiPlus/BizHawk.Bizware.BizwareGL.GdiPlus.csproj
+++ b/Bizware/BizHawk.Bizware.BizwareGL.GdiPlus/BizHawk.Bizware.BizwareGL.GdiPlus.csproj
@@ -37,7 +37,7 @@
     <CodeAnalysisRuleSet Condition=" '$(OS)' == 'Windows_NT' ">MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="OpenTK, Version=1.1.0.0, Culture=neutral, PublicKeyToken=bad199fe84eb3df4, processorArchitecture=MSIL">
+    <Reference Include="OpenTK, Version=3.0.1.0, Culture=neutral, PublicKeyToken=bad199fe84eb3df4, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\References\OpenTK.dll</HintPath>
     </Reference>

--- a/Bizware/BizHawk.Bizware.BizwareGL.OpenTK/BizHawk.Bizware.BizwareGL.OpenTK.csproj
+++ b/Bizware/BizHawk.Bizware.BizwareGL.OpenTK/BizHawk.Bizware.BizwareGL.OpenTK.csproj
@@ -41,11 +41,11 @@
     <CodeAnalysisIgnoreBuiltInRules>false</CodeAnalysisIgnoreBuiltInRules>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="OpenTK, Version=1.1.0.0, Culture=neutral, PublicKeyToken=bad199fe84eb3df4, processorArchitecture=MSIL">
+    <Reference Include="OpenTK, Version=3.0.1.0, Culture=neutral, PublicKeyToken=bad199fe84eb3df4, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\References\OpenTK.dll</HintPath>
     </Reference>
-    <Reference Include="OpenTK.GLControl, Version=1.1.0.0, Culture=neutral, PublicKeyToken=bad199fe84eb3df4, processorArchitecture=MSIL">
+    <Reference Include="OpenTK.GLControl, Version=3.0.1.0, Culture=neutral, PublicKeyToken=bad199fe84eb3df4, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\References\OpenTK.GLControl.dll</HintPath>
     </Reference>

--- a/Bizware/BizHawk.Bizware.BizwareGL.SlimDX/BizHawk.Bizware.BizwareGL.SlimDX.csproj
+++ b/Bizware/BizHawk.Bizware.BizwareGL.SlimDX/BizHawk.Bizware.BizwareGL.SlimDX.csproj
@@ -37,7 +37,7 @@
     <CodeAnalysisRuleSet Condition=" '$(OS)' == 'Windows_NT' ">MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="OpenTK, Version=1.1.0.0, Culture=neutral, PublicKeyToken=bad199fe84eb3df4, processorArchitecture=MSIL">
+    <Reference Include="OpenTK, Version=3.0.1.0, Culture=neutral, PublicKeyToken=bad199fe84eb3df4, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\References\OpenTK.dll</HintPath>
     </Reference>

--- a/Bizware/BizHawk.Bizware.BizwareGL/BizHawk.Bizware.BizwareGL.csproj
+++ b/Bizware/BizHawk.Bizware.BizwareGL/BizHawk.Bizware.BizwareGL.csproj
@@ -41,7 +41,7 @@
     <CodeAnalysisIgnoreBuiltInRules>false</CodeAnalysisIgnoreBuiltInRules>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="OpenTK, Version=1.1.0.0, Culture=neutral, PublicKeyToken=bad199fe84eb3df4, processorArchitecture=MSIL">
+    <Reference Include="OpenTK, Version=3.0.1.0, Culture=neutral, PublicKeyToken=bad199fe84eb3df4, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\References\OpenTK.dll</HintPath>
     </Reference>


### PR DESCRIPTION
## DO NOT MERGE YET

There is still much to be done with this (and it is setup to use OTK_Gamepad on windows).

@YoshiRulz 

Can you build and test this branch when you have a second? Unfortunately the OpenTK GamePadConfigurationDatabase doesn't have a mapping for my controller (in fact it doesnt have that many mappings at all: https://github.com/opentk/opentk/blob/master/src/OpenTK/Input/GamePadConfigurationDatabase.cs#L33), so many of the buttons are round the wrong way. I would be interested to see how it plays with your xbone controller.

If some of the mappings are swapped, it would be good if you could tell me how they are swapped (and hopefully they will be similar to mine if wrong).

If you could also check the terminal/output window, I have it writing some gamepad related info. eg. on mine this is:

```
Initialised OpenTK GamePad: Joystick 0 (Unmapped Controller)
OpenTK Mapping: Unmapped Controller
```


